### PR TITLE
README: explicitly state required cucumber version

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ The cucumber task has several configurable properties:
         dryRun = false
     }
 
+## Prerequisites 
+
+You must use cucumber version <b>1.1.5</b> or higher.
+
 ## Coming Soon
 
 * Use of tags


### PR DESCRIPTION
Hi,

I just spent some time trying to use this nice little plugin, until I realized cucumber version 1.1.5 is not just an example, it's a requirement (earlier versions either fail with an InvocationException or simply can't locate the cucumber Backend), and my project used v1.0.8 :poop: .

So I just added this explicit statement to the README, to spare future frustration. 
It may be worth throwing an indicative exception in case a wrong version is used - didn't go that far, sorry..

Thanks!
