### PR TITLE
Made cucumber tests run on windows

### DIFF
--- a/src/test/java/com/excella/gradle/cucumber/BuildHelper.java
+++ b/src/test/java/com/excella/gradle/cucumber/BuildHelper.java
@@ -194,9 +194,15 @@ public class BuildHelper {
 
   public ProcessBuilder processBuilder(boolean useWrapperScript, String... args) {
     List<String> command = new ArrayList<String>();
+    String gradlewScript;
+    if(System.getProperty("os.name").startsWith("Windows")){
+      gradlewScript = "./gradlew.bat";
+    } else {
+      gradlewScript = "./gradlew";
+    }
 
     if (useWrapperScript) {
-      command.add(new File(projectHelper.getProjectDir(), "gradlew").getAbsolutePath());
+      command.add(new File(projectHelper.getProjectDir(), gradlewScript).getAbsolutePath());
     } else {
       command.add("gradle");
     }

--- a/src/test/java/com/excella/gradle/cucumber/Helper.java
+++ b/src/test/java/com/excella/gradle/cucumber/Helper.java
@@ -29,8 +29,14 @@ public class Helper extends TemporaryFolder {
    */
   public List<String> getCucumberPluginClasspath() throws IOException {
     if (cucumberPluginClasspath != null) return cucumberPluginClasspath;
+    String gradlewScript;
+    if(System.getProperty("os.name").startsWith("Windows")){
+      gradlewScript = "./gradlew.bat";
+    } else {
+      gradlewScript = "./gradlew";
+    }
 
-    ProcessRunner runner = new ProcessRunner(new ProcessBuilder(new File("./gradlew").getAbsolutePath(), "-q", "printMainRuntimeClasspath"));
+    ProcessRunner runner = new ProcessRunner(new ProcessBuilder(new File(gradlewScript).getAbsolutePath(), "-q", "printMainRuntimeClasspath"));
     int exitCode = runner.run();
     if (exitCode != 0) {
       throw new IOException("command failed: " + exitCode);
@@ -40,6 +46,7 @@ public class Helper extends TemporaryFolder {
     String line;
     cucumberPluginClasspath = new ArrayList<String>();
     while ((line = reader.readLine()) != null) {
+      line = line.replace("\\","/"); //ensure windows backslashes are replaced with /
       cucumberPluginClasspath.add(line);
     }
     return cucumberPluginClasspath;

--- a/src/test/java/com/excella/gradle/cucumber/StepDefinitions.java
+++ b/src/test/java/com/excella/gradle/cucumber/StepDefinitions.java
@@ -137,7 +137,7 @@ public class StepDefinitions {
   @Then("^I should see a \"([^\"]*)\" line$")
   public void I_should_see_a_line(String line) throws Throwable {
     assertThat(processRunner.getExitCode(), is(0));
-    assertThat(processRunner.getOut().trim(), containsRegex("^\\s*" + line + "\\s*$", Pattern.MULTILINE));
+    assertThat(processRunner.getOut().trim().replace("\\","/"), containsRegex("^\\s*" + line + "\\s*$", Pattern.MULTILINE));
   }
 
   @Then("^I should(n't| not)? see \"([^\"]*)\"$")


### PR DESCRIPTION
It previously wasn't possible to run the cucumber tests for this project under windows. Now it runs gradlew.bat instead of gradlew when running on a windows machine.

Also fixed an issue with windows file separators in the classpath for tests.
