### PR TITLE
cucumberCompile configuration not added to the eclipse classpath

### DIFF
--- a/src/main/groovy/com/excella/gradle/cucumber/CucumberPlugin.groovy
+++ b/src/main/groovy/com/excella/gradle/cucumber/CucumberPlugin.groovy
@@ -65,8 +65,8 @@ class CucumberPlugin  implements Plugin<Project> {
 
             if (project.plugins.hasPlugin("eclipse")) {
                 project.eclipse.classpath {
-                        plusConfigurations += configurations.cucumberCompile
-                        noExportConfigurations += configurations.cucumberCompile
+                        plusConfigurations += cucumberCompile
+                        noExportConfigurations += cucumberCompile
                     }
             }
 


### PR DESCRIPTION
Similar to a previous issue with Intellij IDEA, the cucumber jars are not automatically added to the Eclipse classpath. Therefore generated Eclipse projects fail to compile unless the jars are explicitly added in the build.gradle.

With this change the jars are appended to the classpath in exclipse but excluded from the export.
