### PR TITLE
only add classpath as glue dir directory

### DIFF
--- a/src/main/groovy/com/excella/gradle/cucumber/tasks/CucumberTask.groovy
+++ b/src/main/groovy/com/excella/gradle/cucumber/tasks/CucumberTask.groovy
@@ -66,34 +66,8 @@ class CucumberTask extends DefaultTask  {
 
     private List<String> getOrDetectGlueDirs() {
         List<String> dirs = getGlueDirs() ?: []
-        List<SourceSet> glueSourceSets = getSourceSets()
-
-        if (!dirs && !glueSourceSets) {
-            dirs = ['src/test/java'] // default
-
-        } else if (glueSourceSets) {
-            glueSourceSets.each { sourceSet ->
-                // add output resources dir for non-Java-class implementations
-                dirs << sourceSet.output.resourcesDir.path
-
-                if (sourceSet.output.classesDir.exists()) {
-                    // add all subdirs of the classes dir for compiled implementations
-                    def packages = new TreeSet()
-                    def classesDirPathLength = sourceSet.output.classesDir.path.length() + 1
-
-                    sourceSet.output.classesDir.traverse { File file ->
-                        if (file.isFile()) {
-                            String relativePath = file.path.substring(classesDirPathLength)
-                            def packageDir = relativePath.
-                                replace(File.separator, '/'). // make sure we are dealing with slashes
-                                replaceFirst('/?[^/]*$', ''). // remove the file name --> keep the parent dir path
-                                replace('/', '.') // turn into a package name
-                            packages << "classpath:${packageDir}".toString()
-                        }
-                    }
-                    dirs.addAll(packages)
-                }
-            }
+        if(dirs.isEmpty()){
+          dirs.add("classpath:")
         }
         dirs.unique()
     }


### PR DESCRIPTION
Because of cucumbers recursiveness only add the classpath to the glue dirs if none is specified. This fixes the problem if you are not having all steps in the same directory!